### PR TITLE
paths started with dot, slash or tylda

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,20 @@ exactly what I needed.
 It accepts a string array and returns a hash containing commands and options.
 
 ```ruby
-Minimist.parse("parse this --with=2 -asbd -n4 --no-changes --send two".split(" "))
+Minimist.parse("parse this --with=2 -asbd -n4 --no-changes --send two -f .hidden.txt".split(" "))
 
 => {
   :commands=>["parse", "this"],
   :options=> {
-    :with=>"2",
+    :with=>:"2",
     :a=>true,
     :s=>true,
     :b=>true,
     :d=>true,
-    :n=>"4",
+    :n=>:"4",
     :changes=>false,
-    :send=>"two"
+    :send=>:two,
+    :f=>:".hidden.txt"
   }
 }
 ```

--- a/lib/minimist.rb
+++ b/lib/minimist.rb
@@ -70,7 +70,7 @@ module Minimist
       #
       if match_data = arg.match(/^-([A-Za-z])([0-9])$/)
         argv_object[:options][match_data[1].to_sym] = match_data[2]
-      elsif @argv[index + 1] =~ /^(\d|[A-Za-z])/
+      elsif @argv[index + 1] =~ /^(\d|[A-Za-z]|[\.\/\~])/
         argv_object[:options][arg.slice(1..-1).to_sym] = transform(@argv[index + 1])
         should_skip = true
       else


### PR DESCRIPTION
Without those changes parser was returning error when parsing "-f ~/file".
With those changes it is possible to have arguments starting with dot, slash or tylda.